### PR TITLE
Added new scripts for benchmarking updateParametersInContext

### DIFF
--- a/development/performance/update_params_benchmark/python27_openmm71.yml
+++ b/development/performance/update_params_benchmark/python27_openmm71.yml
@@ -1,0 +1,12 @@
+name: py27-minimal-openmm-7.1
+channels:
+- MDAnalysis
+- omnia
+- defaults
+dependencies:
+- python=2.7
+- openmm=7.1
+- openmmtools
+- openmoltools
+
+

--- a/development/performance/update_params_benchmark/python27_openmm72.yml
+++ b/development/performance/update_params_benchmark/python27_openmm72.yml
@@ -1,0 +1,13 @@
+name: py27-minimal-openmm-7.2
+channels:
+- MDAnalysis
+- omnia
+- omnia/label/dev
+- defaults
+dependencies:
+- python=2.7
+- openmm=7.2
+- openmmtools
+- openmoltools
+
+

--- a/development/performance/update_params_benchmark/python35_openmm71.yml
+++ b/development/performance/update_params_benchmark/python35_openmm71.yml
@@ -1,0 +1,50 @@
+name: py35-minimal-openmm-7.1
+channels:
+- MDAnalysis
+- omnia
+- defaults
+dependencies:
+- alabaster=0.7.9=py35_0
+- babel=2.3.4=py35_0
+- docutils=0.13.1=py35_0
+- hdf5=1.8.17=1
+- imagesize=0.7.1=py35_0
+- jinja2=2.9.5=py35_0
+- libgcc=4.8.5=1
+- markupsafe=0.23=py35_2
+- mkl=2017.0.1=0
+- nose=1.3.7=py35_1
+- numexpr=2.6.2=np112py35_0
+- numpy=1.12.0=py35_0
+- numpydoc=0.6.0=py35_0
+- openssl=1.0.2k=0
+- pandas=0.19.2=np112py35_1
+- pip=9.0.1=py35_1
+- pygments=2.1.3=py35_0
+- pytables=3.3.0=np112py35_0
+- python=3.5.2=0
+- python-dateutil=2.6.0=py35_0
+- pytz=2016.10=py35_0
+- readline=6.2=2
+- requests=2.13.0=py35_0
+- scipy=0.18.1=np112py35_1
+- setuptools=27.2.0=py35_0
+- six=1.10.0=py35_0
+- snowballstemmer=1.2.1=py35_0
+- sphinx=1.5.1=py35_0
+- sqlite=3.13.0=0
+- tk=8.5.18=0
+- wheel=0.29.0=py35_0
+- xz=5.2.2=1
+- zlib=1.2.8=3
+- ambermini=16.16.0=7
+- fftw3f=3.3.4=2
+- mdtraj=1.8.0=np112py35_1
+- openmm=7.1.0rc1=py35_0
+- openmmtools=0.8.3=py35_1
+- openmoltools=0.7.4=py35_0
+- parmed=2.7.3=py35_0
+- pip:
+  - tables==3.3.0
+prefix: /Users/rossg/miniconda3/envs/minimal-openmm-7.1
+

--- a/development/performance/update_params_benchmark/python35_openmm72.yml
+++ b/development/performance/update_params_benchmark/python35_openmm72.yml
@@ -1,0 +1,51 @@
+name: py35-minimal-openmm-7.2
+channels:
+- MDAnalysis
+- omnia
+- omnia/label/dev
+- defaults
+dependencies:
+- alabaster=0.7.9=py35_0
+- babel=2.3.4=py35_0
+- docutils=0.13.1=py35_0
+- hdf5=1.8.17=1
+- imagesize=0.7.1=py35_0
+- jinja2=2.9.5=py35_0
+- libgcc=4.8.5=1
+- markupsafe=0.23=py35_2
+- mkl=2017.0.1=0
+- nose=1.3.7=py35_1
+- numexpr=2.6.2=np112py35_0
+- numpy=1.12.0=py35_0
+- numpydoc=0.6.0=py35_0
+- openssl=1.0.2k=0
+- pandas=0.19.2=np112py35_1
+- pip=9.0.1=py35_1
+- pygments=2.1.3=py35_0
+- pytables=3.3.0=np112py35_0
+- python=3.5.2=0
+- python-dateutil=2.6.0=py35_0
+- pytz=2016.10=py35_0
+- readline=6.2=2
+- requests=2.13.0=py35_0
+- scipy=0.18.1=np112py35_1
+- setuptools=27.2.0=py35_0
+- six=1.10.0=py35_0
+- snowballstemmer=1.2.1=py35_0
+- sphinx=1.5.1=py35_0
+- sqlite=3.13.0=0
+- tk=8.5.18=0
+- wheel=0.29.0=py35_0
+- xz=5.2.2=1
+- zlib=1.2.8=3
+- ambermini=16.16.0=7
+- fftw3f=3.3.4=2
+- mdtraj=1.8.0=np112py35_1
+- openmm=7.2
+- openmmtools=0.8.3=py35_1
+- openmoltools=0.7.4=py35_0
+- parmed=2.7.3=py35_0
+- pip:
+  - tables==3.3.0
+prefix: /Users/rossg/miniconda3/envs/minimal-openmm-7.1
+

--- a/development/performance/update_params_benchmark/read_profile.py
+++ b/development/performance/update_params_benchmark/read_profile.py
@@ -1,0 +1,12 @@
+import pstats
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Read output profile (pstat) data from cProfile")
+    parser.add_argument('-f','--filename',type=str,help="the filename of the cProfile output",default="profile0")
+    parser.add_argument('-n','--number',type=int,help="the top number of longest running algorithms by total time, default=50",default=50)
+    args = parser.parse_args()
+
+p = pstats.Stats(args.filename)
+p.strip_dirs()
+p.sort_stats('cumulative').print_stats(args.number)

--- a/development/performance/update_params_benchmark/run_benchmarks.sh
+++ b/development/performance/update_params_benchmark/run_benchmarks.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+PLAT='CPU'
+LEN=30
+
+# Python 2.7, openmm 7.1
+conda env create -f python27_openmm71.yml
+source activate py27-minimal-openmm-7.1
+python time_update_parameters.py -l $LEN -o py27_openmm71_plat_${PLAT}_len_${LEN}.pstat --platform $PLAT
+source deactivate py27-minimal-openmm-7.1
+
+# Python 3.5, openmm 7.1
+conda env create -f python35_openmm71.yml
+source activate py35-minimal-openmm-7.1
+python time_update_parameters.py -l $LEN -o py35_openmm71_plat_${PLAT}_len_${LEN}.pstat --platform $PLAT
+source deactivate py35-minimal-openmm-7.1
+
+
+# Python 2.7, openmm 7.2 dev
+conda env create -f python27_openmm72.yml
+source activate py27-minimal-openmm-7.2
+python time_update_parameters.py -l $LEN -o py27_openmm72_plat_${PLAT}_len_${LEN}.pstat --platform $PLAT
+source deactivate py27-minimal-openmm-7.2
+
+# Python 3.5, openmm 7.2 dev
+conda env create -f python35_openmm72.yml
+source activate py35-minimal-openmm-7.2
+python time_update_parameters.py -l $LEN -o py35_openmm72_plat_${PLAT}_len_${LEN}.pstat --platform $PLAT
+source deactivate py35-minimal-openmm-7.2

--- a/development/performance/update_params_benchmark/summary.md
+++ b/development/performance/update_params_benchmark/summary.md
@@ -1,0 +1,47 @@
+# Benchmarks for `updateParametersInContext`
+Summary for timings of `run_benchmarks.sh` for water box length=30 Angs
+and various platforms. This results indicates that on GPUs, `updateParametersInContext` 
+runs ~4 times slower in OpenMM 7.2 than 7.1.
+
+## GTX Titan, CUDA 8.0
+####Python 3.5, OpenMM 7.1
+```
+ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+20000    0.024    0.000    7.078    0.000 openmm.py:8705(updateParametersInContext)
+```
+####Python 3.5, OpenMM 7.2
+```
+ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+20000    0.024    0.000   30.505    0.002 openmm.py:8705(updateParametersInContext)
+```
+####Python 2.7, OpenMM 7.1
+```
+ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+20000    0.023    0.000    7.241    0.000 openmm.py:8705(updateParametersInContext)
+```
+####Python 2.7, OpenMM 7.2
+```
+ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+20000    0.027    0.000   30.655    0.002 openmm.py:8705(updateParametersInContext)
+```
+## CPU (iMac, 3.2 GHz Intel Core i5)
+####Python 3.5, OpenMM 7.1
+```
+ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+20000    0.016    0.000   10.123    0.001 openmm.py:16121(updateParametersInContext)
+```
+####Python 3.5, OpenMM 7.2
+```
+ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+20000    0.016    0.000   10.189    0.001 openmm.py:16121(updateParametersInContext)
+```
+####Python 2.7, OpenMM 7.1
+```
+ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+20000    0.016    0.000    9.449    0.000 openmm.py:16121(updateParametersInContext)
+```
+####Python 2.7, OpenMM 7.2
+```
+ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+20000    0.017    0.000   10.154    0.001 openmm.py:16121(updateParametersInContext)
+```

--- a/development/performance/update_params_benchmark/time_update_parameters.py
+++ b/development/performance/update_params_benchmark/time_update_parameters.py
@@ -1,0 +1,67 @@
+from simtk import openmm, unit
+from simtk.openmm import app
+from openmmtools.testsystems import WaterBox
+
+"""
+Script to time the functions 'setParticleParameters' and 'updateParametersInContext' in OpenMM by partially deleting
+and re-instating a water molecule in a box of water molecules.
+"""
+
+def make_water_system(length=20.0, cutoff=9.0, platform='CUDA', equil_steps=10):
+    """
+    Create a box of TIP3P water and return the compenents of the OpenMM system.
+    """
+    wbox = WaterBox(box_edge=length * unit.angstrom, cutoff=cutoff * unit.angstrom, nonbondedMethod=app.PME)
+    integrator = openmm.LangevinIntegrator(300*unit.kelvin, 1/unit.picosecond, 0.002*unit.picoseconds)
+    if platform == 'CUDA':
+        openmm_platform = openmm.Platform.getPlatformByName('CUDA')
+        properties = {'CudaPrecision': 'mixed'}
+        context = openmm.Context(wbox.system, integrator, openmm_platform, properties)
+    elif platform == 'OpenCL':
+        openmm_platform = openmm.Platform.getPlatformByName('OpenCL')
+        properties = {'OpenCLPrecision': 'mixed'}
+        context = openmm.Context(wbox.system, integrator, openmm_platform, properties)
+    else:
+        context = openmm.Context(wbox.system, integrator)
+    context.setPositions(wbox.positions)
+    context.setVelocitiesToTemperature(300*unit.kelvin)
+    integrator.step(equil_steps)
+    return context, integrator, wbox
+
+def switch_water_force(force, context,frac=0.9):
+    """
+    Switch the non-bonded parameters of the first TIP3P water molecule to some specified fraction of the default values.
+    """
+    force.setParticleParameters(0, charge=-0.834*frac, sigma=0.3150752406575124*frac, epsilon=0.635968*frac)
+    force.setParticleParameters(1, charge=0.417*frac, sigma=0, epsilon=1*frac)
+    force.setParticleParameters(2, charge=0.417*frac, sigma=0, epsilon=1*frac)
+    force.updateParametersInContext(context)
+
+def run_timing(length=20.0, niterations=20, platform='CPU'):
+    """
+    Perform repeated switches of the non-bonded parameters of the first water molecule in the system
+    """
+    # Create the test system:
+    context, integrator, wbox = make_water_system(length=length, platform=platform)
+    # Get the non-bonded force:
+    force = wbox.system.getForce(2)       # Non-bonded force.
+    # Turn the first water molecule in the systen on and off for many iterations:
+    for i in range(niterations):
+        switch_water_force(force, context, frac=0.5)
+        switch_water_force(force, context, frac=1.0)
+
+if __name__ == "__main__":
+    import argparse
+    from cProfile import run
+    parser = argparse.ArgumentParser(description="Run an openmm simulation with salt exchange moves.")
+    parser.add_argument('-l','--length',type=float,
+                        help="the length of one side of the water box in Angstroms, default=20.0", default=20.0)
+    parser.add_argument('-n','--niterations',type=int,
+                        help="the number of iterations to turn a water molecule on and off, default=20", default=10000)
+    parser.add_argument('-o','--out',type=str, help="the filename of the text cProfile file", default="profile.pstat")
+    parser.add_argument('--platform', type=str, choices = ['CPU','CUDA','OpenCL'],
+                        help="the platform where the simulation will be run, default=CPU", default='CPU')
+    args = parser.parse_args()
+
+    # Run cProfile on the non-bonded parameter switches on the water box
+    run('run_timing(length=args.length, niterations=args.niterations, platform=args.platform)', filename=args.out)


### PR DESCRIPTION
A set of scripts have been written for benchmarking `updateParametersInContext` in various different `conda` environments. The test system is a box of water in which the non-bonded parameters of a water molecule are switched partially 'off' and 'on'.