### PR TITLE
New data storage tool

### DIFF
--- a/development/initial_calibration/Titration_cuda/run_calibration.py
+++ b/development/initial_calibration/Titration_cuda/run_calibration.py
@@ -93,15 +93,15 @@ if __name__ == "__main__":
         sampler.move()
         iter_time = time() - iter_start
         # Saving acceptance probability data:
-        cnts = sampler.saltswap.get_identity_counts()
-        acc = sampler.saltswap.get_acceptance_probability()
+        cnts = sampler.swapper.get_identity_counts()
+        acc = sampler.swapper.get_acceptance_probability()
         if args.nprop != 0 and args.propagator == 'GHMC':
-            ghmc_acc = np.mean(np.array(sampler.saltswap.naccepted_ncmc_integrator))
+            ghmc_acc = np.mean(np.array(sampler.swapper.naccepted_ncmc_integrator))
             equil_acc = ghmc_equilibrium.getGlobalVariableByName('naccept') / ghmc_equilibrium.getGlobalVariableByName('ntrials')
         else:
             ghmc_acc = 0.0
             equil_acc = 0.0
-        sampler.saltswap.naccepted_ncmc_integrator = []
+        sampler.swapper.naccepted_ncmc_integrator = []
         f = open(args.data, 'a')
         s = "{:4} {:5} {:5}   {:0.2f}      {:0.2f}         {:0.2f}         {:0.1f}\n".format(i, cnts[0], cnts[1], round(acc,2), round(ghmc_acc,2), round(equil_acc,2), iter_time)
         f.write(s)
@@ -116,5 +116,5 @@ if __name__ == "__main__":
     f = open(args.data, 'a')
     s = "\nElapsed time in seconds = {:0.1f}".format(tm)
     f.write(s)
-    s = "\nNumber of NaNs = {:3}\n".format(sampler.saltswap.nan)
+    s = "\nNumber of NaNs = {:3}\n".format(sampler.swapper.nan)
     f.write(s)

--- a/development/initial_calibration/Titration_opencl2/run_sampler.py
+++ b/development/initial_calibration/Titration_opencl2/run_sampler.py
@@ -82,13 +82,13 @@ if __name__ == "__main__":
         sampler.move()
         iter_time = time() - iter_start
         # Saving acceptance probability data:
-        cnts = sampler.saltswap.get_identity_counts()
-        acc = sampler.saltswap.get_acceptance_probability()
+        cnts = sampler.swapper.get_identity_counts()
+        acc = sampler.swapper.get_acceptance_probability()
         if args.nprop != 0 and args.propagator == 'GHMC':
-            ghmc_acc = np.mean(np.array(sampler.saltswap.naccepted_ncmc_integrator))
+            ghmc_acc = np.mean(np.array(sampler.swapper.naccepted_ncmc_integrator))
         else:
             ghmc_acc = 0
-        sampler.saltswap.naccepted_ncmc_integrator = []
+        sampler.swapper.naccepted_ncmc_integrator = []
         f = open(args.data, 'a')
         s = "{:4} {:5} {:5}   {:0.2f}      {:0.2f}       {:0.1f}\n".format(i, cnts[0], cnts[1], round(acc,2), round(ghmc_acc,2), iter_time)
         f.write(s)
@@ -96,18 +96,18 @@ if __name__ == "__main__":
         # Reset acceotance saltswap acceptance rate
         #sampler.saltswap.reset_statistics()
         # Saving work data for each of the nattempts and reseting:
-        if len(sampler.saltswap.work_add) >= 0:
+        if len(sampler.swapper.work_add) >= 0:
             f = open("work_add_"+args.data,"a")
-            f.writelines("%s " % item  for item in sampler.saltswap.work_add)
+            f.writelines("%s " % item  for item in sampler.swapper.work_add)
             f.write("\n")
             f.close()
-            sampler.saltswap.work_add=[]
-        if len(sampler.saltswap.work_rm) >= 0:
+            sampler.swapper.work_add=[]
+        if len(sampler.swapper.work_rm) >= 0:
             f = open("work_rm_"+args.data,"a")
-            f.writelines("%s " % item  for item in sampler.saltswap.work_rm)
+            f.writelines("%s " % item  for item in sampler.swapper.work_rm)
             f.write("\n")
             f.close()
-            sampler.saltswap.work_rm=[]
+            sampler.swapper.work_rm=[]
         pdbfile = open(args.out, 'a')
         positions = sampler.context.getState(getPositions=True,enforcePeriodicBox=True).getPositions(asNumpy=True)
         app.PDBFile.writeModel(wbox.topology, positions, file=pdbfile, modelIndex=i+1)
@@ -118,5 +118,5 @@ if __name__ == "__main__":
     f = open(args.data, 'a')
     s = "\nElapsed time in seconds = {:0.1f}".format(tm)
     f.write(s)
-    s = "\nNumber of NaNs = {:3}\n".format(sampler.saltswap.nan)
+    s = "\nNumber of NaNs = {:3}\n".format(sampler.swapper.nan)
     f.write(s)

--- a/development/initial_calibration/run_calibration.py
+++ b/development/initial_calibration/run_calibration.py
@@ -91,15 +91,15 @@ if __name__ == "__main__":
         sampler.move()
         iter_time = time() - iter_start
         # Saving acceptance probability data:
-        cnts = sampler.saltswap.get_identity_counts()
-        acc = sampler.saltswap.get_acceptance_probability()
+        cnts = sampler.swapper.get_identity_counts()
+        acc = sampler.swapper.get_acceptance_probability()
         if args.nprop != 0 and args.propagator == 'GHMC':
-            ghmc_acc = np.mean(np.array(sampler.saltswap.naccepted_ncmc_integrator))
+            ghmc_acc = np.mean(np.array(sampler.swapper.naccepted_ncmc_integrator))
             equil_acc = ghmc_equilibrium.getGlobalVariableByName('naccept') / ghmc_equilibrium.getGlobalVariableByName('ntrials')
         else:
             ghmc_acc = 0.0
             equil_acc = 0.0
-        sampler.saltswap.naccepted_ncmc_integrator = []
+        sampler.swapper.naccepted_ncmc_integrator = []
         f = open(args.data, 'a')
         s = "{:4} {:5} {:5}   {:0.2f}      {:0.2f}         {:0.2f}         {:0.1f}\n".format(i, cnts[0], cnts[1], round(acc,2), round(ghmc_acc,2), round(equil_acc,2), iter_time)
         f.write(s)
@@ -114,5 +114,5 @@ if __name__ == "__main__":
     f = open(args.data, 'a')
     s = "\nElapsed time in seconds = {:0.1f}".format(tm)
     f.write(s)
-    s = "\nNumber of NaNs = {:3}\n".format(sampler.saltswap.nan)
+    s = "\nNumber of NaNs = {:3}\n".format(sampler.swapper.nan)
     f.write(s)

--- a/development/initial_calibration/run_sams.py
+++ b/development/initial_calibration/run_sams.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         sampler.move(delta_chem=float(z[1]))
         iter_time = time() - iter_start
         # Saving acceptance probability data:
-        cnts = sampler.saltswap.get_identity_counts()
+        cnts = sampler.swapper.get_identity_counts()
 
         # Update SAMS estimator
         state = cnts[1]
@@ -111,31 +111,31 @@ if __name__ == "__main__":
         z = adaptor.update(state=state, noisy_observation=noisy, histogram=histogram)
 
         # Save data
-        acc = sampler.saltswap.get_acceptance_probability()
+        acc = sampler.swapper.get_acceptance_probability()
         if args.nprop != 0 and args.propagator == 'GHMC':
-            ghmc_acc = np.mean(np.array(sampler.saltswap.naccepted_ncmc_integrator))
+            ghmc_acc = np.mean(np.array(sampler.swapper.naccepted_ncmc_integrator))
         else:
             ghmc_acc = 0
         equil_acc = ghmc_equilibrium.getGlobalVariableByName('naccept') / ghmc_equilibrium.getGlobalVariableByName('ntrials')
-        sampler.saltswap.naccepted_ncmc_integrator = []
+        sampler.swapper.naccepted_ncmc_integrator = []
         f = open(args.data, 'a')
         s = "{:4} {:5} {:5}   {:0.2f}         {:0.2f}      {:0.2f}         {:0.1f}      {:0.3f}\n".format(i, cnts[0], cnts[1], round(acc,2), round(ghmc_acc,2), round(equil_acc,2), iter_time, z[1])
         f.write(s)
         f.close()
 
         # Saving work data for each of the nattempts and reseting:
-        if len(sampler.saltswap.work_add) >= 0:
+        if len(sampler.swapper.work_add) >= 0:
             f = open("work_add_"+args.data,"a")
-            f.writelines("%s " % item  for item in sampler.saltswap.work_add)
+            f.writelines("%s " % item  for item in sampler.swapper.work_add)
             f.write("\n")
             f.close()
-            sampler.saltswap.work_add=[]
-        if len(sampler.saltswap.work_rm) >= 0:
+            sampler.swapper.work_add=[]
+        if len(sampler.swapper.work_rm) >= 0:
             f = open("work_rm_"+args.data,"a")
-            f.writelines("%s " % item  for item in sampler.saltswap.work_rm)
+            f.writelines("%s " % item  for item in sampler.swapper.work_rm)
             f.write("\n")
             f.close()
-            sampler.saltswap.work_rm=[]
+            sampler.swapper.work_rm=[]
 
         # Save trajectory
         positions = sampler.context.getState(getPositions=True, enforcePeriodicBox=True).getPositions(asNumpy=True)
@@ -147,5 +147,5 @@ if __name__ == "__main__":
     f = open(args.data, 'a')
     s = "\nElapsed time in seconds = {:0.1f}".format(tm)
     f.write(s)
-    s = "\nNumber of NaNs = {:3}\n".format(sampler.saltswap.nan)
+    s = "\nNumber of NaNs = {:3}\n".format(sampler.swapper.nan)
     f.write(s)

--- a/examples/run_sampler.py
+++ b/examples/run_sampler.py
@@ -82,13 +82,13 @@ if __name__ == "__main__":
         sampler.move()
         iter_time = time() - iter_start
         # Saving acceptance probability data:
-        cnts = sampler.saltswap.get_identity_counts()
-        acc = sampler.saltswap.get_acceptance_probability()
+        cnts = sampler.swapper.get_identity_counts()
+        acc = sampler.swapper.get_acceptance_probability()
         if args.nprop != 0 and args.propagator == 'GHMC':
-            ghmc_acc = np.mean(np.array(sampler.saltswap.naccepted_ncmc_integrator))
+            ghmc_acc = np.mean(np.array(sampler.swapper.naccepted_ncmc_integrator))
         else:
             ghmc_acc = 0
-        sampler.saltswap.naccepted_ghmc = []
+        sampler.swapper.naccepted_ghmc = []
         f = open(args.data, 'a')
         s = "{:4} {:5} {:5}   {:0.2f}      {:0.2f}       {:0.1f}\n".format(i, cnts[0], cnts[1], round(acc,2), round(ghmc_acc,2), iter_time)
         f.write(s)
@@ -96,18 +96,18 @@ if __name__ == "__main__":
         # Reset acceotance saltswap acceptance rate
         #sampler.saltswap.reset_statistics()
         # Saving work data for each of the nattempts and reseting:
-        if len(sampler.saltswap.work_add) >= 0:
+        if len(sampler.swapper.work_add) >= 0:
             f = open("work_add_"+args.data,"a")
-            f.writelines("%s " % item  for item in sampler.saltswap.work_add)
+            f.writelines("%s " % item  for item in sampler.swapper.work_add)
             f.write("\n")
             f.close()
-            sampler.saltswap.work_add=[]
-        if len(sampler.saltswap.work_rm) >= 0:
+            sampler.swapper.work_add=[]
+        if len(sampler.swapper.work_rm) >= 0:
             f = open("work_rm_"+args.data,"a")
-            f.writelines("%s " % item  for item in sampler.saltswap.work_rm)
+            f.writelines("%s " % item  for item in sampler.swapper.work_rm)
             f.write("\n")
             f.close()
-            sampler.saltswap.work_rm=[]
+            sampler.swapper.work_rm=[]
         pdbfile = open(args.out, 'a')
         positions = sampler.context.getState(getPositions=True,enforcePeriodicBox=True).getPositions(asNumpy=True)
         app.PDBFile.writeModel(wbox.topology, positions, file=pdbfile, modelIndex=i+1)
@@ -118,5 +118,5 @@ if __name__ == "__main__":
     f = open(args.data, 'a')
     s = "\nElapsed time in seconds = {:0.1f}".format(tm)
     f.write(s)
-    s = "\nNumber of NaNs = {:3}\n".format(sampler.saltswap.nan)
+    s = "\nNumber of NaNs = {:3}\n".format(sampler.swapper.nan)
     f.write(s)

--- a/saltswap/record.py
+++ b/saltswap/record.py
@@ -1,0 +1,150 @@
+"""
+File to record saltswap simulation data with netcdf.
+"""
+from netCDF4 import Dataset
+import numpy as np
+from simtk import unit, openmm
+import simtk
+
+# The simulation parameters that will be recorded from Swapper.
+swapper_control_attributes = ('temperature', 'pressure', 'delta_chem', 'npert')
+
+# Establishing default units for recording data. The netcdf file will also be storing units where appropriate.
+variable_states = {'volume':unit.nanometer**3, 'potential energy':unit.kilojoule_per_mole}
+
+class CreateNetCDF(object):
+    """
+    Class to record data from MD and saltswap simulations
+    """
+    def __init__(self, filename):
+        """
+        Create a netcdf file to store saltswap simulation data.
+
+        Parameters
+        ----------
+        filename: str
+            the name of the netcdf file that will be created
+        """
+        self.ncfile = Dataset(filename, 'w', format='NETCDF4')
+        self.scalar_dim = self.ncfile.createDimension('scalar', 1)
+        self.string_dim = self.ncfile.createDimension('string', 0)
+        self.ncfile.createDimension('iteration', None)
+        self.ncfile.createDimension('attempt', None)
+
+    def init_control_variables(self, swapper, variable_dic=None):
+        """
+        Initial simulation saving netcdf parameters.
+
+        Parameters
+        ----------
+        swapper: saltswap.swapper
+            the driver for saltswap
+        variable_dic: dic
+            dictionary containing additional parameters to be stored
+        """
+        # Creating a group for the simulation parameters, e.g. temperature, chemical potential, timesteps etc,
+        control_parms_group = self.ncfile.createGroup('Control parameters')
+
+        # Saving the control parameters that are accessible from the saltswap swapper:
+        for attribute in swapper_control_attributes:
+            atrb = getattr(swapper, attribute)
+            if type(atrb) == simtk.unit.quantity.Quantity:
+                var = control_parms_group.createVariable(attribute, 'f8')
+                control_parms_group.variables[attribute][0] = atrb._value
+                var.unit = atrb.unit._name
+            elif type(atrb) == float:
+                control_parms_group.createVariable(attribute, 'f8')
+                control_parms_group.variables[attribute][0] = atrb
+            elif type(atrb) == int:
+                control_parms_group.createVariable(attribute, 'i8')
+                control_parms_group.variables[attribute][0] = atrb
+
+        # Saving the control parameters that listed in the parameter dictionary:
+        for attribute in variable_dic:
+            atrb = variable_dic[attribute]
+            if type(atrb) == simtk.unit.quantity.Quantity:
+                var = control_parms_group.createVariable(attribute, 'f8')
+                control_parms_group.variables[attribute][0] = atrb._value
+                var.unit = atrb.unit._name
+            elif type(atrb) == float:
+                control_parms_group.createVariable(attribute, 'f8')
+                control_parms_group.variables[attribute][0] = atrb
+            elif type(atrb) == int:
+                control_parms_group.createVariable(attribute, 'i8')
+                control_parms_group.variables[attribute][0] = atrb
+            elif type(atrb) == str:
+                control_parms_group.createVariable(attribute, str, 'string')
+                control_parms_group.variables[attribute][:] = np.array([atrb], "O")
+
+        self.ncfile.sync()
+
+    def init_sample_state_variables(self, swapper):
+        """
+        Recording the simulation variables.
+        """
+        sample_state_group = self.ncfile.createGroup('Sample state data')
+
+        # Scalar quantities with their units
+        for variable in variable_states:
+            var = sample_state_group.createVariable(variable, 'f8', ('iteration', 'scalar'))
+            var.unit = variable_states[variable].get_name()
+
+        # Which molecule is which
+        sample_state_group.createDimension('identity', len(swapper.mutable_residues))
+        sample_state_group.createVariable('identities', 'i8', ('iteration', 'identity'))
+
+        # How many water, cations, and anions there are.
+        sample_state_group.createDimension('species', len(swapper.get_identity_counts()))
+        sample_state_group.createVariable('species counts', 'i8', ('iteration', 'species'))
+
+        # The cumulative work for each NCMC step in thermal units (i.e. unitless)
+        sample_state_group.createDimension('attempt', None)
+        sample_state_group.createDimension('npert', swapper.npert + 1)
+        var = sample_state_group.createVariable('cumulative work', 'f8', ('iteration', 'attempt', 'npert'))
+        var.unit = 'unitless'
+        # The corresponding proposal for the NCMC protocol work
+        sample_state_group.createDimension('proposal', 2)
+        sample_state_group.createVariable('ncmc proposal', 'i8', ('iteration', 'attempt', 'proposal',))
+
+        # The number of saltswap moves that have been accepted
+        sample_state_group.createVariable('naccepted', 'i8', ('iteration', 'attempt', 'scalar',))
+
+        self.ncfile.sync()
+
+    def create_netcdf(self, swapper, variable_dic=None):
+
+        self.init_control_variables(swapper, variable_dic)
+        self.init_sample_state_variables(swapper)
+
+        self.ncfile.sync()
+
+        return self.ncfile
+
+def record_netcdf(ncfile, context, swapper, iteration, attempt=0, sync=True):
+    """
+    Store the variables in the context and swapper objects.
+    """
+    # Openmm state information
+    state = context.getState(getPositions=True, getEnergy=True, enforcePeriodicBox=True)
+
+    volume = state.getPeriodicBoxVolume()
+    var_units = variable_states['volume']
+    ncfile.groups['Sample state data']['volume'][iteration, :] = volume.value_in_unit(var_units)
+
+    potential_energy = state.getPotentialEnergy()
+    var_units = variable_states['potential energy']
+    ncfile.groups['Sample state data']['potential energy'][iteration, :] = potential_energy .value_in_unit(var_units)
+
+    # saltswap state information
+    ncfile.groups['Sample state data']['identities'][iteration, :] = swapper.stateVector
+    ncfile.groups['Sample state data']['species counts'][iteration, :] = swapper.get_identity_counts()
+
+    # saltswap MCMC information
+    ncfile.groups['Sample state data']['ncmc proposal'][iteration, attempt, :] = swapper.proposal
+    ncfile.groups['Sample state data']['cumulative work'][iteration, attempt, :] = swapper.cumulative_work
+    ncfile.groups['Sample state data']['naccepted'][iteration, attempt, :] = swapper.naccepted
+
+    if sync:
+        ncfile.sync()
+
+    return ncfile

--- a/saltswap/tests/test_perturbation.py
+++ b/saltswap/tests/test_perturbation.py
@@ -46,7 +46,7 @@ class TestParamPerturbations(object):
         size = 15.0 * unit.angstrom
         wbox = WaterBox(box_edge = size, nonbondedMethod = app.PME, cutoff = size/2 - 0.5*unit.angstrom)
         state = MCMCSampler(wbox.system, wbox.topology, wbox.positions, delta_chem = 0, nprop = 0, npert = 1)
-        saltswap = state.saltswap
+        saltswap = state.swapper
 
         # Extract the water parameters of the system
         param_matrix = self._get_params(saltswap,0)
@@ -69,7 +69,7 @@ class TestParamPerturbations(object):
         size = 15.0 * unit.angstrom
         wbox = WaterBox(box_edge = size, nonbondedMethod = app.PME, cutoff = size/2 - 0.5*unit.angstrom)
         state = MCMCSampler(wbox.system, wbox.topology, wbox.positions, delta_chem = Dmu_insert, nprop = 0, npert = 1)
-        saltswap = state.saltswap
+        saltswap = state.swapper
 
         # Get the parameters of water before any perturbations
         water_inital_params = copy.deepcopy( self._get_params(saltswap,0) )
@@ -106,7 +106,7 @@ class TestParamPerturbations(object):
         size = 15.0 * unit.angstrom
         wbox = WaterBox(box_edge = size, nonbondedMethod = app.PME, cutoff = size/2 - 0.5*unit.angstrom)
         state = MCMCSampler(wbox.system, wbox.topology, wbox.positions, delta_chem = Dmu_insert, nprop = 1, npert = 10)
-        saltswap = state.saltswap
+        saltswap = state.swapper
 
         # Insert salt using a chemical potential that makes this highly likely. Stop when 1 salt pair has been inserted.
         nosalt = True
@@ -138,7 +138,7 @@ class TestParamPerturbations(object):
         size = 15.0 * unit.angstrom
         wbox = WaterBox(box_edge = size, nonbondedMethod = app.PME, cutoff = size/2 - 0.5*unit.angstrom)
         state = MCMCSampler(wbox.system, wbox.topology, wbox.positions, delta_chem = Dmu_insert, nprop = 0, npert = 1)
-        saltswap = state.saltswap
+        saltswap = state.swapper
 
         # Get the parameters of water before any perturbations
         water_inital_params = copy.deepcopy( self._get_params(saltswap,0) )
@@ -173,7 +173,7 @@ class TestParamPerturbations(object):
         size = 15.0 * unit.angstrom
         wbox = WaterBox(box_edge = size, nonbondedMethod = app.PME, cutoff = size/2 - 0.5*unit.angstrom)
         state = MCMCSampler(wbox.system, wbox.topology, wbox.positions, delta_chem = Dmu_insert, nprop = 1, npert = 10)
-        saltswap = state.saltswap
+        saltswap = state.swapper
 
         # Get the parameters of water before any perturbations
         water_inital_params = copy.deepcopy( self._get_params(saltswap,0) )

--- a/saltswap/tests/test_recorder.py
+++ b/saltswap/tests/test_recorder.py
@@ -1,0 +1,87 @@
+from simtk import openmm, unit
+from openmmtools.testsystems import WaterBox
+from simtk.openmm import app
+
+from saltswap.swapper import Swapper
+from openmmtools import integrators
+from saltswap.record import CreateNetCDF, record_netcdf, sample_variables
+
+from netCDF4 import Dataset
+import numpy as np
+
+class TestRecorder(object):
+    def create_waterbox_example(self):
+        """
+        Create a example system to simulate and record.
+        """
+        temperature = 300. * unit.kelvin
+        timestep = 2. * unit.femtoseconds
+        collision_rate = 90. / unit.picoseconds
+        pressure = 1. * unit.atmospheres
+        box_edge = 20.0 * unit.angstrom
+        npert = 10
+        splitting = 'V R R R O R R R V'
+
+        # Make the water box test system with a fixed pressure
+        wbox = WaterBox(box_edge=box_edge, nonbondedMethod=app.PME, cutoff=9 * unit.angstrom, ewaldErrorTolerance=1E-4)
+        wbox.system.addForce(openmm.MonteCarloBarostat(pressure, temperature))
+
+        # Create the compound integrator
+        langevin = integrators.LangevinIntegrator(splitting=splitting, temperature=temperature, timestep=timestep,
+                                                  collision_rate=collision_rate)
+        ncmc_langevin = integrators.ExternalPerturbationLangevinIntegrator(splitting=splitting, temperature=temperature,
+                                                                           timestep=timestep,
+                                                                           collision_rate=collision_rate)
+        integrator = openmm.CompoundIntegrator()
+        integrator.addIntegrator(langevin)
+        integrator.addIntegrator(ncmc_langevin)
+
+        # Create context
+        platform = openmm.Platform.getPlatformByName('CPU')
+        context = openmm.Context(wbox.system, integrator, platform)
+        context.setPositions(wbox.positions)
+
+        salinator = Swapper(system=wbox.system, topology=wbox.topology, temperature=temperature, delta_chem=0.0,
+                                    ncmc_integrator=ncmc_langevin, pressure=pressure, npert=npert, nprop=1)
+
+        return langevin, context, salinator
+
+
+    def test_write_read(self):
+        """
+        Test that saving data occurs without error and can be loaded without error.
+        """
+        langevin, context, salinator = self.create_waterbox_example()
+
+        # Control parameters for the simulation
+        simulation_control_parameters = {'timestep': 2*unit.femtoseconds, 'splitting':'V R R R O R R R V',
+                                         'box_edge': 20.0*unit.angstrom, 'collision_rate': 90./unit.picoseconds}
+
+        # Create the netcdf file
+        filename = 'test_recorder.nc'
+        creator = CreateNetCDF(filename)
+        ncfile = creator.create_netcdf(salinator, simulation_control_parameters)
+
+        niterations = 3
+        nattempts = 2
+        for iteration in range(niterations):
+            langevin.step(10)
+            for attempt in range(nattempts):
+                salinator.update(context, nattempts=1)
+                record_netcdf(ncfile, context, salinator, iteration, attempt=attempt, sync=True)
+
+        # Extract and store the results for easy testing
+        saved_results = []
+        for var in sample_variables:
+            saved_results.append(ncfile.groups['Sample state data'][var][:])
+
+        # Close netcdf file
+        ncfile.close()
+
+        # Re-open netcdf file and make sure it's the same as before
+        opened_ncfile = Dataset(filename, 'r')
+
+        # Make sure the uploaded numerical values are the same as before
+        for var, res in zip(sample_variables, saved_results):
+            assert np.all(opened_ncfile.groups['Sample state data'][var][:] == res)
+

--- a/saltswap/tests/test_zero_energy_swaps.py
+++ b/saltswap/tests/test_zero_energy_swaps.py
@@ -39,15 +39,15 @@ class TestZeroEnergySwaps(object):
         # Create the box of water to simulate
         wbox = WaterBox(box_edge = size, nonbondedMethod=app.PME, cutoff=size/2 - 0.5*unit.angstrom)
         dummystate = MCMCSampler(wbox.system, wbox.topology, wbox.positions, delta_chem=Dmu, nprop=0, npert=1)
-        dummystate.saltswap.cation_parameters = dummystate.saltswap.water_parameters    # Setting the cation parameters to water's
-        dummystate.saltswap.anion_parameters = dummystate.saltswap.water_parameters     # Setting the anion parameters to water's
-        dummystate.saltswap._set_parampath()     # Recalculating the peturbation path for new paramters
+        dummystate.swapper.cation_parameters = dummystate.swapper.water_parameters    # Setting the cation parameters to water's
+        dummystate.swapper.anion_parameters = dummystate.swapper.water_parameters     # Setting the anion parameters to water's
+        dummystate.swapper._set_parampath()     # Recalculating the peturbation path for new paramters
 
         # Sampling. Recording the ratio of water to salt every 20 attempts and repeated Nsamps times.
         ratio = []
         for batch in range(Nsamps):
             dummystate.gen_label(saltsteps=10)
-            (nwats,nsalt,junk) = dummystate.saltswap.get_identity_counts()
+            (nwats,nsalt,junk) = dummystate.swapper.get_identity_counts()
             ratio.append(1.0*nwats/nsalt)
         ratio = np.array(ratio)
         ratio_mean = np.mean(ratio)
@@ -76,15 +76,15 @@ class TestZeroEnergySwaps(object):
         # Create the box of water to simulate
         wbox = WaterBox(box_edge=size, nonbondedMethod=app.PME, cutoff=size/2 - 0.5*unit.angstrom)
         dummystate = MCMCSampler(wbox.system, wbox.topology, wbox.positions, delta_chem = Dmu, nprop=1, npert=3, propagator='GHMC')
-        dummystate.saltswap.cation_parameters = dummystate.saltswap.water_parameters    # Setting the cation parameters to water's
-        dummystate.saltswap.anion_parameters = dummystate.saltswap.water_parameters     # Setting the anion parameters to water's
-        dummystate.saltswap._set_parampath()     # Recalculating the peturbation path for new paramters
+        dummystate.swapper.cation_parameters = dummystate.swapper.water_parameters    # Setting the cation parameters to water's
+        dummystate.swapper.anion_parameters = dummystate.swapper.water_parameters     # Setting the anion parameters to water's
+        dummystate.swapper._set_parampath()     # Recalculating the peturbation path for new paramters
 
         # Sampling. Recording the ratio of water to salt every 20 attempts and repeated Nsamps times.
         ratio = []
         for batch in range(Nsamps):
             dummystate.gen_label(saltsteps=10)
-            (nwats,nsalt,junk) = dummystate.saltswap.get_identity_counts()
+            (nwats,nsalt,junk) = dummystate.swapper.get_identity_counts()
             ratio.append(1.0*nwats/nsalt)
         ratio = np.array(ratio)
         ratio_mean = np.mean(ratio)


### PR DESCRIPTION
Created a new `netcdf` storage module for a stable way to record `saltswap` simulation data. The previous way of storing results used text files with custom write-read functions. Basing the storage system on netcdf with a unit-tested interface is a more sustainable option.