### PR TITLE
Minor changes to the storage of simulation results

### DIFF
--- a/saltswap/record.py
+++ b/saltswap/record.py
@@ -117,6 +117,10 @@ class CreateNetCDF(object):
 
         # The number of saltswap moves that have been accepted
         sample_state_group.createVariable('naccepted', 'i8', ('iteration', 'attempt', 'scalar',), zlib=True)
+        sample_state_group.createVariable('nattempted', 'i8', ('iteration', 'attempt', 'scalar',), zlib=True)
+
+        # The log acceptance probability for each attempt
+        sample_state_group.createVariable('log_accept', 'f8', ('iteration', 'attempt', 'scalar',), zlib=True)
 
         self.ncfile.sync()
 
@@ -168,7 +172,9 @@ def record_netcdf(ncfile, context, swapper, iteration, attempt=0, sync=True):
     # saltswap MCMC information
     ncfile.groups['Sample state data']['proposal'][iteration, attempt, :] = swapper.proposal
     ncfile.groups['Sample state data']['cumulative work'][iteration, attempt, :] = swapper.cumulative_work
-    ncfile.groups['Sample state data']['naccepted'][iteration, attempt, :] = swapper.naccepted
+    ncfile.groups['Sample state data']['naccepted'][iteration, attempt, 0] = swapper.naccepted
+    ncfile.groups['Sample state data']['nattempted'][iteration, attempt, 0] = swapper.naccepted
+    ncfile.groups['Sample state data']['log_accept'][iteration, attempt, 0] =  swapper.log_accept
 
     if sync:
         ncfile.sync()

--- a/saltswap/tests/test_recorder.py
+++ b/saltswap/tests/test_recorder.py
@@ -51,6 +51,8 @@ class TestRecorder(object):
         """
         Test that saving data occurs without error and can be loaded without error.
         """
+        from os import remove
+
         langevin, context, salinator = self.create_waterbox_example()
 
         # Control parameters for the simulation
@@ -58,7 +60,7 @@ class TestRecorder(object):
                                          'box_edge': 20.0*unit.angstrom, 'collision_rate': 90./unit.picoseconds}
 
         # Create the netcdf file
-        filename = 'test_recorder.nc'
+        filename = 'test_recorder_temporary_file.nc'
         creator = CreateNetCDF(filename)
         ncfile = creator.create_netcdf(salinator, simulation_control_parameters)
 
@@ -84,4 +86,6 @@ class TestRecorder(object):
         # Make sure the uploaded numerical values are the same as before
         for var, res in zip(sample_variables, saved_results):
             assert np.all(opened_ncfile.groups['Sample state data'][var][:] == res)
+
+        remove(filename)
 


### PR DESCRIPTION
Details
-------
* The recorder class now saves the log acceptance probability and number of attempts. `Saltswap.Swapper` has been modified to allow the former.
* The cumulative protocol work was being stored in `Swapper` as variables in numerous different ways. As these have now been superseded by the recording of the proposal and associated cumulative work, the superfluous variables have now been removed
* The test for the reading and writing of NetCDF storage file now removes the temporary file that gets created during for the test.