### PR TITLE
A wrapper for performing SAMS

### DIFF
--- a/examples/run_calibration.py
+++ b/examples/run_calibration.py
@@ -1,0 +1,166 @@
+from simtk import openmm, unit
+from openmmtools.testsystems import WaterBox
+from simtk.openmm import app
+
+import numpy as np
+
+from saltswap import wrappers,
+from openmmtools import integrators
+import saltswap.record as Record
+from bams.sams_adapter import SAMSAdaptor
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Run a saltswap simulation on a box of water.")
+    parser.add_argument('-o','--out', type=str,
+                        help="the naming scheme of the output results, default=out", default="out")
+    parser.add_argument('-b','--box_edge', type=float,
+                        help="length of the water box edge in Angstroms, default=30", default=30.0)
+    parser.add_argument('-i','--iterations', type=int,
+                        help="the number of iterations of MD and saltswap moves, default=10000", default=10000)
+    parser.add_argument('-s','--steps', type=int,
+                        help="the number of MD steps per iteration, default=2000", default=2000)
+    parser.add_argument('--save_freq', type=int,
+                        help="the frequency with which to save the data", default=4)
+    parser.add_argument('--timestep', type=float,
+                        help='the timestep of the integrators in femtoseconds, default=2.0', default=2.0)
+    parser.add_argument('-e','--equilibration', type=int,
+                        help="the number of equilibration steps, default=5000", default=5000)
+    parser.add_argument('--model', type=str, choices=['tip3p','tip4pew'],
+                        help="the water model, default=tip4ew", default='tip4pew')
+    parser.add_argument('--npert', type=int,
+                        help="the number of ncmc perturbation kernels, default=10000", default=10000)
+    parser.add_argument('--saltmax', type=int,
+                        help="the maximum number of salt pairs that will be accepted, default=20", default=20)
+    parser.add_argument('--platform', type=str, choices=['CPU','CUDA','OpenCL'],
+                        help="the platform where the simulation will be run, default=CPU", default='CPU')
+    parser.add_argument('--save_configs', action='store_true',
+                        help="whether to save the configurations of the box of water, default=False", default=False)
+    args = parser.parse_args()
+
+    # Setting the parameters of the simulation
+    timestep = args.timestep * unit.femtoseconds
+    box_edge = args.box_edge * unit.angstrom
+    npert = args.npert
+
+    # Fixed simulation parameters
+    splitting = 'V R O R V'
+    temperature = 300.*unit.kelvin
+    collision_rate = 1./unit.picoseconds
+    pressure = 1.*unit.atmospheres
+
+    # Make the water box test system with a fixed pressure
+    wbox = WaterBox(model=args.model, box_edge=box_edge, nonbondedMethod=app.PME, cutoff=10*unit.angstrom, ewaldErrorTolerance=1E-4)
+    wbox.system.addForce(openmm.MonteCarloBarostat(pressure, temperature))
+
+    # Create the compound integrator
+    langevin = integrators.LangevinIntegrator(splitting=splitting, temperature=temperature, timestep=timestep,
+                                              collision_rate=collision_rate, measure_shadow_work=False,
+                                              measure_heat=False)
+    ncmc_langevin = integrators.ExternalPerturbationLangevinIntegrator(splitting=splitting, temperature=temperature,
+                                                                       timestep=timestep, collision_rate=collision_rate,
+                                                                       measure_shadow_work=False, measure_heat=False)
+    integrator = openmm.CompoundIntegrator()
+    integrator.addIntegrator(langevin)
+    integrator.addIntegrator(ncmc_langevin)
+
+    # Create context
+    if args.platform == 'CUDA':
+        platform = openmm.Platform.getPlatformByName('CUDA')
+        platform.setPropertyDefaultValue('DeterministicForces', 'true')
+        properties = {'CudaPrecision': 'mixed'}
+        context = openmm.Context(wbox.system, integrator, platform, properties)
+    elif args.platform == 'OpenCL':
+        platform = openmm.Platform.getPlatformByName('OpenCL')
+        properties = {'OpenCLPrecision': 'mixed'}
+        context = openmm.Context(wbox.system, integrator, platform, properties)
+    elif args.platform == 'CPU':
+        platform = openmm.Platform.getPlatformByName('CPU')
+        context = openmm.Context(wbox.system, integrator, platform)
+    else:
+        raise Exception('Platform name {0} not recognized.'.format(args.platform))
+
+    context.setPositions(wbox.positions)
+    context.setVelocitiesToTemperature(temperature)
+
+    # Create the swapper object for the insertion and deletion of salt
+    # Create the salinator object for the insertion and deletion of salt
+    sams_salinator = wrappers.SAMSSalinator(context=context, system=wbox.system, topology=wbox.topology,
+                                   ncmc_integrator=ncmc_langevin, salt_concentration=0.1*unit.molar,
+                                   pressure=pressure, temperature=temperature, npert=npert, water_name='HOH', )
+
+    mcdriver = Swapper(system=wbox.system, topology=wbox.topology, temperature=temperature, delta_chem=0.0,
+                        ncmc_integrator=ncmc_langevin, pressure=pressure, npert=npert, nprop=1)
+
+    # Thermalize the system
+    langevin.step(args.equilibration)
+
+    # Create the netcdf file for non-configuration simulation data
+    filename = args.out + '.nc'
+    creator = Record.CreateNetCDF(filename)
+    simulation_control_parameters = {'timestep': timestep, 'splitting': splitting, 'box_edge': box_edge,
+                                     'collision_rate': collision_rate}
+    ncfile = creator.create_netcdf(mcdriver, simulation_control_parameters)
+    # Create an additional dimension to store sams bias
+    ncfile.createDimension('nsalt', args.saltmax + 1)
+    ncfile.groups['Sample state data'].createVariable('sams bias', 'f8', ('iteration', 'nsalt'), zlib=True)
+
+    if args.save_configs:
+        # Create PDB file to view with the (binary) dcd file.
+        positions = context.getState(getPositions=True, enforcePeriodicBox=True).getPositions(asNumpy=True)
+        pdbfile = open(args.out + '.pdb', 'w')
+        app.PDBFile.writeHeader(wbox.topology, file=pdbfile)
+        app.PDBFile.writeModel(wbox.topology, positions, file=pdbfile, modelIndex=0)
+        pdbfile.close()
+
+        # Create a DCD file system configurations
+        dcdfile = open(args.out + '.dcd', 'wb')
+        dcd = app.DCDFile(file=dcdfile, topology=wbox.topology, dt=timestep)
+
+    # Initialize SAMS adaptor
+    initial_guess = 317.0
+    # Initializing the  bias using the free energy to insert a single salt molecule
+    bias = np.arange(args.saltmax + 1) * initial_guess
+    adaptor = SAMSAdaptor(nstates=args.saltmax + 1, zetas=bias, beta=0.6, flat_hist=0.1)
+    state_counts = np.zeros(args.saltmax + 1)
+
+    # Proposal mechanism for SAMS
+    def gen_penalty(nsalt, bias, saltmax):
+        if nsalt == saltmax:
+            penalty = [0.0, bias[nsalt - 1] - bias[nsalt]]
+        elif nsalt == 0:
+            penalty = [bias[nsalt + 1] - bias[nsalt], 0.0]
+        else:
+            penalty = [bias[nsalt + 1] - bias[nsalt],
+                       bias[nsalt - 1] - bias[nsalt]]
+        return penalty
+
+    # The actual simulation
+    k = 0
+    for iteration in range(args.iterations):
+        # Establish the free energy penalty for adding or removing more salt
+        nwater, ncation, nanion = mcdriver.get_identity_counts()
+        penalty = gen_penalty(ncation, bias, args.saltmax)
+
+        # Propagate configurations and salt concentrations
+        langevin.step(args.steps)
+        mcdriver.attempt_identity_swap(context, penalty=penalty, saltmax=args.saltmax)
+
+        # Update SAMS estimator
+        nwater, ncation, nanion = mcdriver.get_identity_counts()
+        noisy = np.zeros(args.saltmax + 1)
+        noisy[ncation] = 1
+        state_counts[ncation] += 1
+        bias = adaptor.update(state=ncation, noisy_observation=noisy, histogram=state_counts)
+
+        # Save data
+        if iteration % args.save_freq == 0:
+            # Record the simulation data
+            Record.record_netcdf(ncfile, context, mcdriver, k, attempt=0, sync=False)
+            ncfile.groups['Sample state data']['sams bias'][k, :] = bias
+            ncfile.sync()
+            if args.save_configs:
+                # Record the simulation configurations
+                positions = context.getState(getPositions=True, enforcePeriodicBox=True).getPositions(asNumpy=True)
+                dcd.writeModel(positions=positions)
+            k += 1

--- a/saltswap/record.py
+++ b/saltswap/record.py
@@ -82,7 +82,7 @@ class CreateNetCDF(object):
 
         self.ncfile.sync()
 
-    def init_sample_state_variables(self, swapper, sams_max=None):
+    def init_sample_state_variables(self, swapper, nstates=None):
         """
         Recording the simulation variables.
 
@@ -90,8 +90,8 @@ class CreateNetCDF(object):
         ----------
         swapper: saltswap.swapper
             the driver for saltswap
-        sams_max: int or None.
-            if running a Self Adjusted Mixture Simulation, this is maximum number of salt pairs that will be inserted.
+        nstates: int or None.
+            if running a Self Adjusted Mixture Simulation, this is number of states.
         """
         sample_state_group = self.ncfile.createGroup('Sample state data')
 
@@ -125,13 +125,13 @@ class CreateNetCDF(object):
         sample_state_group.createVariable('log_accept', 'f4', ('iteration', 'attempt'), zlib=True)
 
         # The biases from self-adjusted mixture sampling.
-        if sams_max is not None:
-            sample_state_group.createDimension('nsalt', sams_max + 1)
-            sample_state_group.createVariable('sams bias', 'f8', ('iteration', 'nsalt'), zlib=True)
+        if nstates is not None:
+            sample_state_group.createDimension('nstates', nstates)
+            sample_state_group.createVariable('sams bias', 'f8', ('iteration', 'nstates'), zlib=True)
 
         self.ncfile.sync()
 
-    def create_netcdf(self, swapper, variable_dic=None, sams_max=None):
+    def create_netcdf(self, swapper, variable_dic=None, nstates=None):
         """
         Create a
         Parameters
@@ -140,11 +140,11 @@ class CreateNetCDF(object):
             the driver for saltswap
         variable_dic: dic
             dictionary containing additional parameters to be stored
-        sams_max: int or None
-            if running SAMS, the maximum number of salt pairs that will be inserted.
+        nstates: int or None
+            The number of SAMS states if performing this simulation type..
         """
         self.init_control_variables(swapper, variable_dic)
-        self.init_sample_state_variables(swapper, sams_max)
+        self.init_sample_state_variables(swapper, nstates)
 
         self.ncfile.sync()
 

--- a/saltswap/record.py
+++ b/saltswap/record.py
@@ -141,9 +141,11 @@ class CreateNetCDF(object):
         variable_dic: dic
             dictionary containing additional parameters to be stored
         nstates: int or None
-            The number of SAMS states if performing this simulation type..
+            The number of SAMS states if performing this simulation type.
         """
-        self.init_control_variables(swapper, variable_dic)
+        if variable_dic is not None:
+            self.init_control_variables(swapper, variable_dic)
+
         self.init_sample_state_variables(swapper, nstates)
 
         self.ncfile.sync()

--- a/saltswap/record.py
+++ b/saltswap/record.py
@@ -82,7 +82,7 @@ class CreateNetCDF(object):
 
         self.ncfile.sync()
 
-    def init_sample_state_variables(self, swapper):
+    def init_sample_state_variables(self, swapper, sams_max=None):
         """
         Recording the simulation variables.
 
@@ -90,6 +90,8 @@ class CreateNetCDF(object):
         ----------
         swapper: saltswap.swapper
             the driver for saltswap
+        sams_max: int or None.
+            if running a Self Adjusted Mixture Simulation, this is maximum number of salt pairs that will be inserted.
         """
         sample_state_group = self.ncfile.createGroup('Sample state data')
 
@@ -122,9 +124,14 @@ class CreateNetCDF(object):
         # The log acceptance probability for each attempt
         sample_state_group.createVariable('log_accept', 'f4', ('iteration', 'attempt'), zlib=True)
 
+        # The biases from self-adjusted mixture sampling.
+        if sams_max is not None:
+            sample_state_group.createDimension('nsalt', sams_max + 1)
+            sample_state_group.createVariable('sams bias', 'f8', ('iteration', 'nsalt'), zlib=True)
+
         self.ncfile.sync()
 
-    def create_netcdf(self, swapper, variable_dic=None):
+    def create_netcdf(self, swapper, variable_dic=None, sams_max=None):
         """
         Create a
         Parameters
@@ -133,15 +140,17 @@ class CreateNetCDF(object):
             the driver for saltswap
         variable_dic: dic
             dictionary containing additional parameters to be stored
+        sams_max: int or None
+            if running SAMS, the maximum number of salt pairs that will be inserted.
         """
         self.init_control_variables(swapper, variable_dic)
-        self.init_sample_state_variables(swapper)
+        self.init_sample_state_variables(swapper, sams_max)
 
         self.ncfile.sync()
 
         return self.ncfile
 
-def record_netcdf(ncfile, context, swapper, iteration, attempt=0, sync=True):
+def record_netcdf(ncfile, context, swapper, iteration, attempt=0, sams_bias=None, sync=True):
     """
     Store the variables in the context and swapper objects.
 
@@ -153,6 +162,8 @@ def record_netcdf(ncfile, context, swapper, iteration, attempt=0, sync=True):
         Contains the OpenMM simulation data and parameters
     swapper: saltswap.swapper
         the driver for saltswap
+    sams_bias: numpy.ndarray or None.
+        the Self Adjusted Mixture Sampling weights.
     """
     # Openmm state information
     state = context.getState(getPositions=True, getEnergy=True, enforcePeriodicBox=True)
@@ -175,6 +186,9 @@ def record_netcdf(ncfile, context, swapper, iteration, attempt=0, sync=True):
     ncfile.groups['Sample state data']['naccepted'][iteration, attempt] = swapper.naccepted
     ncfile.groups['Sample state data']['nattempted'][iteration, attempt] = swapper.nattempted
     ncfile.groups['Sample state data']['log_accept'][iteration, attempt] =  swapper.log_accept
+
+    if sams_bias is not None:
+        ncfile.groups['Sample state data']['sams bias'][iteration, :] = sams_bias
 
     if sync:
         ncfile.sync()

--- a/saltswap/sams_adapter.py
+++ b/saltswap/sams_adapter.py
@@ -6,7 +6,8 @@ class SAMSAdaptor(object):
     Rao-Blackwellized or binary update schemes. To function, this class must be paired with a method to perform mixture
     sampling over states and configurations.
 
-    [1] Journal of Computational and Graphical Statistics Vol. 26 , Iss. 1, 2017
+    [1] Z. Tan, "Optimally adjusted mixture sampling and locally weighted histogram analysis", Journal of Computational
+    and Graphical Statistics Vol. 26 , Iss. 1, 2017
 
     Example
     -------

--- a/saltswap/sams_adapter.py
+++ b/saltswap/sams_adapter.py
@@ -31,9 +31,9 @@ class SAMSAdaptor(object):
     Next, we'll initialize this SAMS update class, which will estimates given samples from states. We'll be using the
     two-stage scheme as described in equation 15 of [1], which will perform a burn-in for the free energies:
 
-    >>> adaptor = SAMSAdaptor(nstates=len(true_free_energies), two_stage=True, flat_hist=0.2)
+    >>> adaptor = SAMSAdaptor(nstates=len(true_free_energies), two_stage=True, precision=0.2)
 
-    The burn-in stage will finish when the state count histogram is within 20% (flat_hist=0.2) of the target weights,
+    The burn-in stage will finish when the state counts are within 20% (precision=0.2) of the target weights,
     which specify the sampling frequencies we want. By default, the target_weights are uniform over the states.
 
     The SAMSAdaptor works by tracking the state of the sampler and updating the bias accordingly. The bias is used to
@@ -58,7 +58,7 @@ class SAMSAdaptor(object):
     true_free_energies.
 
     """
-    def __init__(self, nstates, zetas=None, target_weights=None, two_stage=True, beta=0.6, flat_hist=0.2):
+    def __init__(self, nstates, zetas=None, target_weights=None, two_stage=True, beta=0.6, precision=0.2):
         """
         Parameters
         ----------
@@ -73,7 +73,7 @@ class SAMSAdaptor(object):
             Graphical Statistics Vol. 26 , Iss. 1, 2017. If true, the zeta parameters are adapted faster
         beta: float
             exponent of the gain during the bunr-in phase of the two-stage procedure. Should be between 0.5 and 1.0
-        flat_hist: float
+        precision: float
             degree of deviation that the state histogram can be from the target weights before the burn-in period
             in the two stage procedure ends. It is the maximum relative difference a histogram element can be
             from the respective target weight.
@@ -81,7 +81,7 @@ class SAMSAdaptor(object):
 
         self.nstates = nstates
         self.beta = beta
-        self.flat_hist = flat_hist
+        self.precision = precision
         self.two_stage = two_stage
         self.burnin = True
         self.time = 0
@@ -159,7 +159,7 @@ class SAMSAdaptor(object):
                 # Calculate how far the histogram is from the target weights
                 fraction = 1.0 * histogram / np.sum(histogram)
                 dist = np.max(np.absolute(fraction - self.target_weights) / self.target_weights)
-                if dist <= self.flat_hist:
+                if dist <= self.precision:
                     # If histogram appears suitably flat then switch to slow growth
                     self.burnin = False
                     self.burnin_length = self.time

--- a/saltswap/sams_adapter.py
+++ b/saltswap/sams_adapter.py
@@ -1,0 +1,263 @@
+import numpy as np
+
+class SAMSAdaptor(object):
+    """
+    Implements the update scheme for self adjusted mixture sampling as described by Z. Tan in [1]. Can use either the
+    Rao-Blackwellized or binary update schemes. To function, this class must be paired with a method to perform mixture
+    sampling over states and configurations.
+
+    [1] Journal of Computational and Graphical Statistics Vol. 26 , Iss. 1, 2017
+
+    Example
+    -------
+    Calculating relative free energies of different states using the binary update scheme for samples drawn from a
+    multinomial distribution. For this example, the IndependentMultinomialSampler, defined below, will be used. We know
+    the true free energies in this case, but it serves to demonstrate the basic functionality this class. For this
+    sampler class, we'll use the following as the true free energies:
+
+    >>>  true_free_energies = np.array((0.0, -5.0, -10.0, -15.0))
+
+    The free energies are relative to the first state. SAMS works by applying biases to each state, and updating these
+    biases to achieve user specified sampling frequencies for each state. SAMS achieves by gradually improving estimates
+    of the relative free energies of each state. These estimates are the biases used to achieve the specified sampling
+    frequencies. We'll start off without any biases:
+
+    >>> biases = np.zeros(len(true_free_energies))
+
+    Now, we'll initialize the sampler:
+
+    >>> sampler = IndependentMultinomialSampler(free_energies=true_free_energies, zetas=biases)
+
+    Next, we'll initialize this SAMS update class, which will estimates given samples from states. We'll be using the
+    two-stage scheme as described in equation 15 of [1], which will perform a burn-in for the free energies:
+
+    >>> adaptor = SAMSAdaptor(nstates=len(true_free_energies), two_stage=True, flat_hist=0.2)
+
+    The burn-in stage will finish when the state count histogram is within 20% (flat_hist=0.2) of the target weights,
+    which specify the sampling frequencies we want. By default, the target_weights are uniform over the states.
+
+    The SAMSAdaptor works by tracking the state of the sampler and updating the bias accordingly. The bias is used to
+    sample from the different states at the target probability. There are 4 main stages to calculating free energies
+    with this class. The example below performs 500 iterations of multinomial sampling and SAMS updates and each stage
+    is labeled and described below.
+
+    >>> for i in range(500):
+    >>>     noisy = sampler.step()                 # 1.
+    >>>     z = -adaptor.update(state=sampler.state , noisy_observation=noisy, histogram=sampler.state_counts)     # 3.
+    >>>     sampler.zetas = z              # 4.
+
+    In stage 1., states  sampled over with IndependentMultinomialSampler. The noisy variable is a binary vector with the
+    only non-zero element at the index of the current state. In stage 3., the current state of the sampler, the noisy
+    observation, and the observed state counts are supplied to the SAMS object. The state counts are not essential here,
+    but are necessary if you want to use the two-stage scheme. The new bias required to achieve the target weights for
+    that iteration is returned. In stage 4., the new bias is supplied to the sampler. Thus, the next iteration samples from
+    the mixture with an updated state bias.
+
+    As the number of iterations tends to infinity, the bias will converge to a value that can be used as an unbiased
+    estimate of the free energies. When the target weights are equal, as they are above, the bias tends to
+    true_free_energies.
+
+    """
+    def __init__(self, nstates, zetas=None, target_weights=None, two_stage=True, beta=0.6, flat_hist=0.2):
+        """
+        Parameters
+        ----------
+        nstates: int
+            The number of free energies to infer
+        zeta: numpy array
+            The estimate of the free energy and the current state biasing potential
+        target_weights: numpy array
+            vector of the state probabilities that the sampler should converge to.
+        two_stage: bool
+            whether to perform the two-stage update procedure as outline by Z. Tan in Journal of Computational and
+            Graphical Statistics Vol. 26 , Iss. 1, 2017. If true, the zeta parameters are adapted faster
+        beta: float
+            exponent of the gain during the bunr-in phase of the two-stage procedure. Should be between 0.5 and 1.0
+        flat_hist: float
+            degree of deviation that the state histogram can be from the target weights before the burn-in period
+            in the two stage procedure ends. It is the maximum relative difference a histogram element can be
+            from the respective target weight.
+        """
+
+        self.nstates = nstates
+        self.beta = beta
+        self.flat_hist = flat_hist
+        self.two_stage = two_stage
+        self.burnin = True
+        self.time = 0
+        self.burnin_length = None
+
+        if zetas is None:
+            self.zetas = np.zeros(self.nstates)
+        elif len(zetas) != self.nstates:
+            raise Exception('The length of the  bias/estimate (zetas) array is not equal to nstates')
+        else:
+            self.zetas = zetas
+
+        if target_weights is None:
+            self.target_weights = np.repeat(1.0 / nstates, nstates)
+        else:
+            if len(target_weights) != self.nstates:
+                raise Exception('The length of the target weights array is not equal to nstates')
+            elif np.abs(np.sum(target_weights) - 1.0) > 0.000001:
+                raise Exception('The target weights do not sum to 1.')
+            else:
+                self.target_weights = target_weights
+
+    def _calc_gain(self, state):
+        """
+        Calculates the gain factor for update.
+
+        Parameter
+        ---------
+        state: int
+            the index corresponding to the current state of the sampler
+
+        Returns
+        -------
+        gain:
+            the factor applied to the SAMS derived noisy variable
+        """
+
+        if self.two_stage:
+            if self.burnin:
+                gain = np.min((self.target_weights[state], self.time ** (-self.beta)))
+            else:
+                factor = (self.time - self.burnin_length + self.burnin_length ** (-self.beta)) ** (-1)
+                gain = np.min((self.target_weights[state], factor))
+        else:
+            gain = 1.0 / self.time
+
+        return gain
+
+    def update(self, state, noisy_observation, histogram=None):
+        """
+        Update the estimate of the free energy based on the current state of the sample using either the binary or
+        Rao-Blackwellized schemes, both of these schemes differ only by their noisy observable.
+
+        Parameters
+        ----------
+        state: int
+            the index corresponding to the current state of the sampler
+        noisy_observation: numpy array
+            the vector that will be multiplied by the gain factor when updating zeta
+        histogram:
+            the counts in each state collected over the simulation. Used to decide when to switch to the slow-growth
+            stage if self.two_stage=True. If None, then slow-growth is automatically assumed.
+
+        Returns
+        -------
+        zetas: numpy array
+            the updated estimates for the free energies
+
+        """
+        # Ensure the internal clock is updated. Used for calculating the gain factor.
+        self.time += 1
+
+        if self.two_stage:
+            if self.burnin and histogram is not None:
+                # Calculate how far the histogram is from the target weights
+                fraction = 1.0 * histogram / np.sum(histogram)
+                dist = np.max(np.absolute(fraction - self.target_weights) / self.target_weights)
+                if dist <= self.flat_hist:
+                    # If histogram appears suitably flat then switch to slow growth
+                    self.burnin = False
+                    self.burnin_length = self.time
+            elif self.burnin and histogram is None:
+                # If no histogram is supplied the update scheme switches to slow growth
+                self.burnin = False
+                self.burnin_length = self.time
+
+        gain = self._calc_gain(state)
+        zetas_half = self.zetas + gain * (noisy_observation / self.target_weights)
+        self.zetas = zetas_half - zetas_half[0]
+
+        return self.zetas
+
+class IndependentMultinomialSampler(object):
+    """
+    Class to draw independent samples from a biased multinomial distribution with the following distribution:
+
+        p_i = exp(zeta_i - f_i) / sum_i[exp(zeta_i - f_i)]
+
+    where f_i and zeta_i are the free energy and applied bias the free energy of ith state, respectively. The unbiased
+    distribution has propabilities proportional to exp(-f_i).
+
+    Example
+    -------
+    Specify the free energy difference between each state
+    >>> free_energies = np.array((0.0, -10.0))
+
+    Specify the biases to be applied to each state
+    >>> biases = np.array((0.0, 0.0))
+
+    Initialize the sampler
+    >>> sampler = IndependentMultinomialSampler(free_energies=free_energies, zetas=biases)
+
+    Take 200 uncorrelated global jumps over the states and record the current location in state_vector
+    >>> state_vector = sampler.step(nsteps=200)
+
+    The array state_vector is a binary vector with the only non-zero element at the current state of the system. The
+    index of the non-zero element is given by
+    >>> print(sampler.state)
+
+    View how many times each state was visited over all the steps:
+    >>> print(sampler.state_counts)
+    """
+    def __init__(self, free_energies=None, zetas=None):
+        """
+        Initialize the biased multinomial sampler.
+
+        Parameters
+        ----------
+        free_energies: numpy array
+            the free energy of the unbiased probabilities
+        zetas: numpy array
+            the exponent of the bias applied to the probabilities
+        """
+        if free_energies is None:
+            self.free_energies = np.random.uniform(-50, 50, size=5)
+            self.free_energies -= self.free_energies[0]
+        else:
+            self.free_energies = free_energies
+            self.free_energies -= self.free_energies[0]
+
+        if zetas is not None:
+            self.zetas = zetas
+            self.zetas -= self.zetas[0]
+        else:
+            self.zetas = np.repeat(0.0, len(self.free_energies))
+
+        self.state_counts = np.repeat(0.0, len(self.free_energies))
+
+        self.state = None
+
+    def step(self, nsteps=1):
+        """
+        Sample from multinomial distribution and update the state histogram
+
+        Parameters
+        ----------
+        nsteps: int
+            the number of samples to draw
+
+        Returns
+        -------
+        current_state: numpy array
+            binary array where the only non-zero element indicates the current state of the system
+        """
+        p = np.exp(self.zetas - self.free_energies)
+        p = p / np.sum(p)
+
+        self.state_counts += np.random.multinomial(nsteps - 1, p)
+        current_state = np.random.multinomial(1, p)
+        self.state_counts += current_state
+        self.state = int(np.where(current_state != 0)[0][0])
+
+        return current_state
+
+    def reset_statistics(self):
+        """
+        Reset the histogram state counter to zero
+        """
+        self.state_counts -= self.state_counts

--- a/saltswap/swapper.py
+++ b/saltswap/swapper.py
@@ -14,7 +14,11 @@ to exchange water and salt with the simulation system. This means the number of 
 fluctuating quantity. The constant salt concentration simulation is achieved using the semi grand canonical ensemble,
 which allows molecules/particles to change identity.
 
-Non-equilibrium candidate Monte Carlo (_ncmc) is used to increase acceptance rates of switching.
+
+The wrapper for Swapper is contained in the Salinator class, which allows one to specify the macroscopic
+concentration of the reservior. Instead, one must specify a chemical potential, not concentration to run Swapper.
+
+Non-equilibrium candidate Monte Carlo (ncmc) is used to increase acceptance rates of switching.
 
 Based on code from openmm-constph.
 
@@ -22,7 +26,6 @@ Based on code from openmm-constph.
 Notes
 -----
 
-    * The code is still in development.
     * The Swapper class only performs moves that exchange two  water molecules for an anion-cation pair.
     * Swapper can be combined with molecular dynamics by alternating blocks of Swapper moves and molecular dynamics
      integration steps.
@@ -36,9 +39,7 @@ References
 
 Example
 -------
-
-The OpenMM wrapper for Swapper is contained in the MCMCSampler class, which allows alternating steps of molecular
-dynamics and Swapper moves. To run Swapper without that wrapper, see below for an example using a box of water.
+See below for an example using a box of water and a specified chemical potential.
 
 >>> from simtk import openmm, unit
 >>> from openmmtools.testsystems import WaterBox

--- a/saltswap/tests/test_sams_adaptor.py
+++ b/saltswap/tests/test_sams_adaptor.py
@@ -83,7 +83,7 @@ class TestSAMSAdaptor(object):
         """
         nstates = 10
         target_weights = np.repeat(1.0 / nstates, nstates)
-        adaptor = SAMSAdaptor(nstates=nstates, two_stage=True, flat_hist=0.2, target_weights=target_weights)
+        adaptor = SAMSAdaptor(nstates=nstates, two_stage=True, precision=0.2, target_weights=target_weights)
 
         # Creating a histogram that is far from 'flat' and therefore should not stop the burn-in phase
         histogram = np.arange(nstates)
@@ -103,7 +103,7 @@ class TestSAMSAdaptor(object):
         """
         nstates = 10
         target_weights = np.repeat(1.0 / nstates, nstates)
-        adaptor = SAMSAdaptor(nstates=nstates, two_stage=True, flat_hist=0.2, target_weights=target_weights)
+        adaptor = SAMSAdaptor(nstates=nstates, two_stage=True, precision=0.2, target_weights=target_weights)
 
         # Creating a histogram that matches the target weights. The burn-in should stop.
         histogram = 100 * target_weights

--- a/saltswap/tests/test_sams_adaptor.py
+++ b/saltswap/tests/test_sams_adaptor.py
@@ -1,0 +1,117 @@
+import numpy as np
+from saltswap.sams_adapter import SAMSAdaptor
+
+class TestSAMSAdaptor(object):
+    """
+    Functions to test the SAMS adaptor class
+    """
+
+    def test_sams_clock(self):
+        """
+        Assess that the adaptor accurately logs the number of times it was called and its iteration stage. The SAMS
+        internal clock is used to calculate the gain. Samples will be generated with numpy's multinomial sampler.
+        """
+        # Initialize the SAMS adaptor
+        nstates = 10
+        adaptor = SAMSAdaptor(nstates=nstates)
+
+        # The probabilities for the discrete states
+        probs = np.repeat(1.0 / nstates, nstates)
+
+        # Iterating the sampler and adaptor for few steps
+        niterations = 10
+        for i in range(niterations):
+            noisy = np.random.multinomial(1, probs)
+            state = np.where(noisy != 0)[0][0]
+            adaptor.update(state=state, noisy_observation=noisy)
+
+        assert adaptor.time == niterations
+
+    def test_slow_gain(self):
+        """
+        Ensure the correct gain factor is correctly calculated in the absence of two stage procedure.
+        """
+        # The system and SAMS parameters
+        nstates = 10          # The number of discrete states in the system
+        target_weights = np.repeat(1.0 / nstates, nstates)      # The target probabilities
+        initial_zeta = np.repeat(1.0, nstates)                  # Initial estimate for the free energies
+        initial_zeta -= initial_zeta[0]
+
+        adaptor = SAMSAdaptor(nstates=nstates, two_stage=False, zetas=initial_zeta, target_weights=target_weights)
+
+        # Generate a fake sample for the noisy variable:
+        noisy = np.zeros(nstates)
+        state = 3             # The imagined state of the sampler
+        noisy[state] = 1.0
+
+        new_zetas = adaptor.update(state=state, noisy_observation=noisy)
+        true_new_zeta = initial_zeta[state] + (noisy[state] / target_weights[state]) / adaptor.time
+
+        assert new_zetas[state] == true_new_zeta
+
+    def test_fast_gain(self):
+        """
+        Ensures the gain during the burn-in stage is properly calculated.
+        """
+        # The system and SAMS parameters
+        nstates = 10          # The number of discrete states in the system
+        beta = 0.7            # Exponent of gain factor during burn-in phase.
+        target_weights = np.repeat(1.0 / nstates, nstates)      # The target probabilities
+        initial_zeta = np.repeat(1.0, nstates)                  # Initial estimate for the free energies
+        initial_zeta -= initial_zeta[0]
+
+        adaptor = SAMSAdaptor(nstates=nstates, two_stage=True, zetas=initial_zeta, target_weights=target_weights,
+                              beta=beta)
+
+        # Generate a fake sample for the noisy variable:
+        noisy = np.zeros(nstates)
+        state = 3  # The imagined state of the sampler
+        noisy[state] = 1.0
+
+        new_zetas = adaptor.update(state=state, noisy_observation=noisy, histogram=np.arange(nstates))
+
+        if target_weights[state] < adaptor.time**(-beta):
+            true_new_zeta = initial_zeta[state] + target_weights[state] * (noisy[state] / target_weights[state])
+        else:
+            true_new_zeta = initial_zeta[state] + adaptor.time**(-beta) * (noisy[state] / target_weights[state])
+
+        assert new_zetas[state] == true_new_zeta
+
+    def test_burnin_continuation(self):
+        """
+        Tests whether the burn-in does not stop prematurely
+        """
+        nstates = 10
+        target_weights = np.repeat(1.0 / nstates, nstates)
+        adaptor = SAMSAdaptor(nstates=nstates, two_stage=True, flat_hist=0.2, target_weights=target_weights)
+
+        # Creating a histogram that is far from 'flat' and therefore should not stop the burn-in phase
+        histogram = np.arange(nstates)
+
+        # Creating a fake sample
+        noisy = np.zeros(nstates)
+        state = 3  # The imagined state of the sampler
+        noisy[state] = 1.0
+
+        adaptor.update(state=state, noisy_observation=noisy, histogram=histogram)
+
+        assert adaptor.burnin == True
+
+    def test_burnin_termination(self):
+        """
+        Tests whether the stopping criterion for the burn-in period is correctly implemented.
+        """
+        nstates = 10
+        target_weights = np.repeat(1.0 / nstates, nstates)
+        adaptor = SAMSAdaptor(nstates=nstates, two_stage=True, flat_hist=0.2, target_weights=target_weights)
+
+        # Creating a histogram that matches the target weights. The burn-in should stop.
+        histogram = 100 * target_weights
+
+        noisy = np.zeros(nstates)
+        state = 3  # The imagined state of the sampler
+        noisy[state] = 1.0
+
+        adaptor.update(state=state, noisy_observation=noisy, histogram=histogram)
+
+        assert adaptor.burnin == False


### PR DESCRIPTION
This PR adds a wrapper to simplify running self adjusted mixture sampling (SAMS) simulations with `saltswap`, along with an example script. This type of simulations are important for calibrating the chemical potential and for predicting the sensitivity of protein-ligand binding free energies on the salt concentration.
 
The Record class that keeps track of simulation data has also been updated to make it easier to save the SAMS weights.
 
Previous SAMS simulations of saltswap were dependent on the Bayesian free energy repo for the SAMS implementation. That repo is not expected to be maintenaned in the near future, so the primary SAMS bookkeeping class was brought into this repo.
 
Why
-----
- Greatly simplifies running SAMS `saltswap` simulations.
- Removes the dependency on the (ill-named) `Bayesian Free Energies` repo.